### PR TITLE
update slack channels

### DIFF
--- a/src/reactor/handlers/order.clj
+++ b/src/reactor/handlers/order.clj
@@ -193,17 +193,6 @@
   (format "%s/services/orders/%s" hostname (:db/id order)))
 
 
-(def ^:private property-channel
-  {"52gilbert"   "#52-gilbert"
-   "2072mission" "#2072-mission"
-   "6nottingham" "#6-nottingham"})
-
-
-(defn- notification-channel [db account]
-  (let [code (property/code (account/current-property db account))]
-    (get property-channel code slack/crm)))
-
-
 (defmethod dispatch/notify :order/created
   [deps event {:keys [order-uuid account-id]}]
   (let [order   (order/by-uuid (->db deps) order-uuid)
@@ -241,7 +230,7 @@
       (slack/send
        (->slack deps)
        {:uuid    (event/uuid event)
-        :channel (notification-channel (->db deps) member)}
+        :channel (slack/helping-hands)}
        (sm/msg
         (sm/info
          (sm/title "New Premium Service Order"
@@ -383,7 +372,7 @@
     (slack/send
      (->slack deps)
      {:uuid    (event/uuid event)
-      :channel (notification-channel (->db deps) orderer)}
+      :channel (slack/helping-hands)}
      (sm/msg
       (sm/info
        (sm/title "Helping Hands Order Canceled"

--- a/src/reactor/services/slack.clj
+++ b/src/reactor/services/slack.clj
@@ -72,3 +72,4 @@
 (def crm "#crm")
 (def community "#community")
 (def log "#webserver")
+(def helping-hands "#helping-hands")


### PR DESCRIPTION
per request of community team - send Helping Hands notifs to `#helping-hands` channel